### PR TITLE
fix: correct `module` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://opencollective.com/unified"
   },
   "main": "dist/index.js",
-  "module": "dist/react-markdown.esm.js",
+  "module": "dist/react-remark.esm.js",
   "typings": "dist/index.d.ts",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Merging this PR should fix issue #12.

The `module` property in `package.json` incorrectly referred to `react-markdown.esm.js` while the name of the built file is `react-remark.esm.js`.