### PR TITLE
Fix `useRemarkSync` param type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,11 @@ jobs:
           restore-keys: |
             nodeModules-
 
+      # TODO: Remove when CI supports new peer dep behavior
+      # https://github.com/remarkjs/react-remark/pull/74#issuecomment-1951415731
+      - name: Set legacy-peer-deps=true
+        run: npm config set legacy-peer-deps=true
+
       - name: Install dependencies
         run: npm ci
         env:

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export const useRemarkSync = (
     rehypeReactOptions,
     remarkPlugins = [],
     rehypePlugins = [],
-  }: UseRemarkOptions = {}
+  }: UseRemarkSyncOptions = {}
 ): ReactElement =>
   unified()
     .use(remarkParse, remarkParseOptions)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

It looks like https://github.com/remarkjs/react-remark/pull/18  used the `UseRemarkOptions` type instead of the `UseRemarkSyncOptions` type for the 2nd parameter of the `useRemarkSync()` function:

- https://github.com/remarkjs/react-remark/pull/18/files#r1493819195

It seems incorrect to me because of A) the name and B) the `onError` property not being used.

<!--do not edit: pr-->
